### PR TITLE
tools/signal.h: Fix C++11 compliance.

### DIFF
--- a/tools/signal.cpp
+++ b/tools/signal.cpp
@@ -20,6 +20,14 @@
 #include <cstdlib>
 #include "signal.h"
 
+static volatile std::sig_atomic_t m_sigintAbort = 0;
+
+#ifndef WIN32
+static void (*m_sigHandlerOriginal)(int) = NULL;
+#else
+static PHANDLER_ROUTINE m_sigHandlerRegistered = NULL;
+#endif
+
 void Signal::SetupHandlerForSIGINT(int type)
 {
 	m_sigintAbort = 0;

--- a/tools/signal.h
+++ b/tools/signal.h
@@ -40,16 +40,13 @@ public:
 	static bool ReceivedSIGINT(void);
 
 private:
-	inline static volatile std::sig_atomic_t m_sigintAbort = 0;
 	static void SafeStderrWrite(const char *buf);
 
 #ifndef WIN32
-	inline static void (*m_sigHandlerOriginal)(int) = NULL;
 	static void UnixSetupHandlerForSIGINT(int type);
 	static void UnixGracefulExitHandler(int signal);
 	static void UnixForceExitHandler(int signal);
 #else
-	inline static PHANDLER_ROUTINE m_sigHandlerRegistered = NULL;
 	static void Win32SetupHandlerForConsoleCtrl(int type);
 	static BOOL Win32GracefulExitHandler(DWORD fdwCtrlType);
 	static BOOL Win32ForceExitHandler(DWORD fdwCtrlType);


### PR DESCRIPTION
"inline static" variables are a C++17 feature. To maintain C++11 compliance, move their definitions from signal.h to signal.c (since global variables can't be defined in the header without violating the One Definition Rule).